### PR TITLE
css changes

### DIFF
--- a/front/src/components/UserProfileModal/UserProfileModal.js
+++ b/front/src/components/UserProfileModal/UserProfileModal.js
@@ -73,9 +73,9 @@ function UserProfileModal(props) {
   const customStyles = {
     content: {
       borderRadius: "10px",
-      width: "25%",
+      width: "40%",
       margin: "auto auto",
-      height: "65vh",
+      height: "83vh",
       overflow: "hidden",
     },
   };

--- a/front/src/components/stats/statsInputs.js
+++ b/front/src/components/stats/statsInputs.js
@@ -11,7 +11,7 @@ export default function StatsInputs({ setCalendar, setReverse }) {
 
 
 
-    const [selected, setSelected] = useState("custom");
+    const [selected, setSelected] = useState("today");
     const [custom, setCustom] = useState(false);
 
     const today = format(new Date(), 'isoDate');

--- a/front/src/components/styles.module.css
+++ b/front/src/components/styles.module.css
@@ -498,7 +498,7 @@ select {
 
     border-bottom: 0px;
     border-radius: 8px;
-    z-index: 1;
+    /*z-index: 1;*/
 }
 
 .borderTop {


### PR DESCRIPTION
- Vista por defecto en "Hoy" VENTAS HECHO
- Número de categorías elevado, se podría resetear. PRODUCTOS
- Monto en vista general de ventas no coincide con monto total. SOLO EN VENTAS VIEJAS AUTOGENERADAS. en las nuevas funciona bien
- Modal de PERFIL aparece detrás de PRODUCTOS. SOLVED.
- Modal de PERFIL no tiene ancho y alto suficiente para pantallas más chicas. SOLVED.